### PR TITLE
double_free: check for memory leaks when needed

### DIFF
--- a/double_free/config-memtrack.json
+++ b/double_free/config-memtrack.json
@@ -1,0 +1,53 @@
+{	
+	"file": "double_free.c",
+	"rules":
+	[
+		{
+			"findInstruction": {
+					      "returnValue": "<t1>",
+					      "instruction": "call",
+					      "operands": ["*", "malloc"]
+					   },
+			"newInstruction": {
+					      "returnValue": "*",
+					      "instruction": "call",
+					      "operands": ["<t1>", "1","__INSTR_fsm_change_state"]
+					  },
+			"where": "after",
+			"in": "*"
+		},
+		
+		{
+			"findInstruction": {
+					      "returnValue": "*",
+					      "instruction": "call",
+					      "operands": ["<t1>", "free"]
+					   },
+			"newInstruction": {
+					      "returnValue": "*",
+					      "instruction": "call",
+					      "operands": ["<t1>", "0","__INSTR_fsm_change_state"]
+					  },
+			"where": "before",
+			"in": "*"
+		},
+		
+		{
+			"findInstruction": {
+					      "returnValue": "*",
+					      "instruction": "ret",
+					      "operands": ["*"]
+					   },
+			"newInstruction": {
+					      "returnValue": "*",
+					      "instruction": "call",
+					      "operands": ["__INSTR_fsm_list_destroy_checked"]
+					  },
+			"where": "before",
+			"in": "main"
+		}
+	]
+}
+
+
+

--- a/double_free/double_free.c
+++ b/double_free/double_free.c
@@ -131,3 +131,17 @@ void __INSTR_fsm_list_destroy() {
     }
 
 }
+
+void __INSTR_fsm_list_destroy_checked() {
+    fsm_list_node *cur = fsm_list;
+
+    while(cur) {
+        fsm_list_node *tmp = cur->next;
+	if (cur->fsm->state == FSM_STATE_ALLOCATED)
+		assert(0 && "memory leak detected");
+
+        free(cur->fsm);
+        free(cur);
+        cur = tmp;
+    }
+}


### PR DESCRIPTION
This allows to check if all allocated memory were freed

TODO: maybe we should rename the double_free to something like memtrack?

Signed-off-by: Marek Chalupa <mchqwerty@gmail.com>